### PR TITLE
Removed postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "DataTable component for Angular2 framework",
   "main": "datatable",
   "scripts": {
-    "postinstall": "cd src && typings install",
     "watch": "tsc -p src -w",
     "prebuild": "rm -rf lib",
     "build": "tsc -p src",


### PR DESCRIPTION
It was causing errors. Installing typings does not seem to be necessary for using this package.